### PR TITLE
 refactor: 메뉴 사이드바 요소들 사이즈 변경

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -45,7 +45,7 @@ export default async function RootLayout({
       className="antialiased w-full min-h-screen bg-background max-w-[var(--base-w)] mx-auto
       border-x border-lightGray-5"
     >
-      <body className={`${geistSans.variable} ${geistMono.variable}`}>
+      <body className={`${geistSans.variable} ${geistMono.variable} relative`}>
         <AuthContextProvider isAuth={isAuth}>{children}</AuthContextProvider>
       </body>
     </html>

--- a/src/components/pages/menu/MenuSideBar.tsx
+++ b/src/components/pages/menu/MenuSideBar.tsx
@@ -15,13 +15,13 @@ export default function MenuSideBar({ categories }: Props) {
   return (
     <aside
       className={cn(
-        'fixed top-0 left-0 z-[3000] w-full h-full',
+        'fixed top-0 left-0 z-[3000] w-full h-full ',
         'bg-background backdrop-filter backdrop-blur-xl backdrop-opacity-90',
         'transition-transform duration-300 ease-in-out',
-        isOpen ? 'translate-x-0' : '-translate-x-full'
+        isOpen ? 'translate-x-' : '-translate-x-full'
       )}
     >
-      <div className="w-full h-full">
+      <div className="w-full h-full  max-w-[var(--base-w)] mx-auto">
         <MenuTop />
         <MenuCategoryList categories={categories} />
         <MenuBannerList />


### PR DESCRIPTION
# 🚀 What type of PR is this?

<!-- 괄호안에 x를 작성하면 체크 상태가 됩니다. Preview를 보시고 제대로 적용되었는지 확인해주세요.
ex) [x] -> O     [ x], [ x ], [x ] -> X  -->

- [ ] ✨ New Features (새로운 기능 추가)
- [ ] 🐛 Bug Fix (버그 수정)
- [x] 🛠️ Refactoring (리팩토링)
- [ ] 📝 Documentation Update (문서 수정)
- [ ] 🚀 Performance Improvement (성능 개선)
- [ ] ⚡ ETC (기타 - 이곳에 작성해주세요)

# 🔗 Related Issue
<!-- 해결하는 이슈 번호를 입력하면 PR이 머지될 때 자동으로 해당 이슈가 닫힙니다. -->
<!-- ex) Closes #이슈번호 or Fixes #이슈번호 or Resolves #이슈번호 -->

- #157 

## 💡 Description
<!-- 변경된 내용을 설명해주세요. -->

-

## 📌 Changes
<!-- 어떤 부분이 변경되었나요? -->

- 메뉴 사이드바 웹 화면에서 전체를 다 덮던 것을 페이지 사이즈에 맞게 변경 
- 하지만 슬라이드가 시작되는 부분은 똑같음 ( 어쩔 수 없었음 ...) 
- 사이드바 자체가 화면에서 안보이는 부분에 숨겨져 있다가 나오는 것이기 때문에 화면시작 부분에서 튀어나옴

## 📸 Screenshot (선택 사항)
<!-- 변경 사항을 보여주는 스크린샷을 첨부해주세요. -->
![image](https://github.com/user-attachments/assets/0f61cba5-89a4-4721-b59f-0d6eea5d3072)


## 🔗 Reference
<!-- 참고할 만한 자료, 이슈 또는 관련 PR을 연결해주세요. -->

-
